### PR TITLE
Pin pyribs to older version

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -8,4 +8,4 @@ natsort
 numexpr==2.7.0
 fire
 alive_progress
-ribs[all]
+ribs[all]==0.4.0


### PR DESCRIPTION
Hi @schrum2! I was taking a look at your code and noticed you were using an older version of pyribs. However, your current dependencies would install the latest version of pyribs (0.5.2 right now), which introduced a lot of breaking changes (see here: https://docs.pyribs.org/en/stable/whats-new.html). I’m submitting this PR to pin pyribs to 0.4.0 so that your code does not break. Thank you for using pyribs, and let me know if you have any questions!